### PR TITLE
Fixed gulp build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,10 +7,9 @@ var concat = require('gulp-concat');
 var sassError = require('gulp-sass-error').gulpSassError;
 
 gulp.task('build', function() {
-    gulp.src('src/**/*.scss')
-    .pipe(concat('anything.scss'))
-    .pipe(sass().on('error', sassError(true)))
-    .pipe(gulp.dest('./dist/'));
+       gulp.src('src/anything.scss')
+            .pipe(sass().on('error', sass.logError))
+            .pipe(gulp.dest('./dist/'))
 });
 
 gulp.task('default',function() {

--- a/src/anything.scss
+++ b/src/anything.scss
@@ -1,0 +1,14 @@
+// Constants
+@import 'constants/colors';
+@import 'constants/fonts';
+@import 'constants/transform-mixins';
+
+// Styles
+@import 'styles/anaglyph';
+@import 'styles/col-6';
+@import 'styles/flip';
+@import 'styles/helvetica';
+@import 'styles/rainbow';
+@import 'styles/spin';
+@import 'styles/wow';
+@import 'styles/wow';

--- a/src/anything.scss
+++ b/src/anything.scss
@@ -11,4 +11,3 @@
 @import 'styles/rainbow';
 @import 'styles/spin';
 @import 'styles/wow';
-@import 'styles/wow';


### PR DESCRIPTION
Styles are imported before variables and mixins. This push fixes this
